### PR TITLE
Fix tests on Python 3

### DIFF
--- a/src/zc/recipe/testrunner/README.rst
+++ b/src/zc/recipe/testrunner/README.rst
@@ -372,7 +372,7 @@ include a check for an environment variable:
     ...
     ... class DemoTests(unittest.TestCase):
     ...    def test(self):
-    ...        self.assertEquals('42', os.environ.get('zc.recipe.testrunner', '23'))
+    ...        self.assertEqual('42', os.environ.get('zc.recipe.testrunner', '23'))
     ...
     ... def test_suite():
     ...     return unittest.makeSuite(DemoTests)


### PR DESCRIPTION
They were seeing a deprecation warning they didn't expect to see.

Closes #5.