### PR TITLE
Update config with latest zope.meta. [uv]

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,33 +39,24 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
-    - name: Set up Python
-      uses: actions/setup-python@v5
+    - name: Install uv + caching
+      uses: astral-sh/setup-uv@v5
       with:
-        python-version: ${{ matrix.config[0] }}
-        allow-prereleases: true
-    - name: Pip cache
-      uses: actions/cache@v4
-      with:
-        path: ~/.cache/pip
-        key: ${{ runner.os }}-pip-${{ matrix.config[0] }}-${{ hashFiles('setup.*', 'tox.ini') }}
-        restore-keys: |
-          ${{ runner.os }}-pip-${{ matrix.config[0] }}-
-          ${{ runner.os }}-pip-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install tox
+        enable-cache: true
+        cache-dependency-glob: |
+          setup.*
+          tox.ini
+        python-version: ${{ matrix.matrix.config[0] }}
+        github-token: ${{ secrets.GITHUB_TOKEN }}
     - name: Test
       if: ${{ !startsWith(runner.os, 'Mac') }}
-      run: tox -e ${{ matrix.config[1] }}
+      run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}
     - name: Test (macOS)
       if: ${{ startsWith(runner.os, 'Mac') }}
-      run: tox -e ${{ matrix.config[1] }}-universal2
+      run: uvx --with tox-uv tox -e ${{ matrix.config[1] }}-universal2
     - name: Coverage
       if: matrix.config[1] == 'coverage'
       run: |
-        pip install coveralls
-        coveralls --service=github
+        uvx coveralls --service=github
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/zopefoundation/meta/tree/master/config/buildout-recipe
 [meta]
 template = "buildout-recipe"
-commit-id = "faa4ee89"
+commit-id = "20bb01bb"
 
 [python]
 with-pypy = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,9 @@
 # https://github.com/zopefoundation/meta/tree/master/config/buildout-recipe
 
 [build-system]
-requires = ["setuptools <= 75.6.0"]
+requires = [
+    "setuptools <= 75.6.0",
+]
 build-backend = "setuptools.build_meta"
 
 [tool.coverage.run]
@@ -16,10 +18,23 @@ fail_under = 100
 precision = 2
 ignore_errors = true
 show_missing = true
-exclude_lines = ["pragma: no cover", "pragma: nocover", "except ImportError:", "raise NotImplementedError", "if __name__ == '__main__':", "self.fail", "raise AssertionError", "raise unittest.Skip"]
+exclude_lines = [
+    "pragma: no cover",
+    "pragma: nocover",
+    "except ImportError:",
+    "raise NotImplementedError",
+    "if __name__ == '__main__':",
+    "self.fail",
+    "raise AssertionError",
+    "raise unittest.Skip",
+]
 
 [tool.coverage.html]
 directory = "parts/htmlcov"
 
 [tool.coverage.paths]
-source = ["src/", ".tox/*/lib/python*/site-packages/", ".tox/pypy*/site-packages/"]
+source = [
+    "src/",
+    ".tox/*/lib/python*/site-packages/",
+    ".tox/pypy*/site-packages/",
+]


### PR DESCRIPTION
This adds the `uv` updates.

It will fail due to the whole `pkg_resources` mess.  Locally it is fixed when I update `tox.ini` to use latest setuptools, or when I copy my patch from https://github.com/buildout/buildout/pull/684 into the `zc.buildout` code in a tox environment.

So: this needs a bit more patience.