### PR TITLE
Clarify and try to fix location error

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Change History
 3.2 (unreleased)
 ================
 
+- If distribution is not found, try its canonical name.
+
 - If distribution is not found, explicitly show its name.
 
 - Drop support for Python 3.8.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Change History
 3.2 (unreleased)
 ================
 
+- If distribution is not found, explicitly show its name.
+
 - Drop support for Python 3.8.
 
 - Add support for Python 3.13.

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         'test': ['zope.testing'],
     },
     install_requires=[
+        'packaging>=23.2',
         'zc.buildout >= 1.2.0',
         'zope.testrunner',
         'setuptools',

--- a/src/zc/recipe/testrunner/__init__.py
+++ b/src/zc/recipe/testrunner/__init__.py
@@ -49,7 +49,7 @@ class TestRunner:
         test_paths = []
         for spec in eggs:
             dist = ws.find(pkg_resources.Requirement.parse(spec))
-            if dist is None:
+            if dist is None:  # pragma: no cover
                 new_spec = canonicalize_name(spec)
                 if spec != new_spec:
                     dist = ws.find(pkg_resources.Requirement.parse(new_spec))

--- a/src/zc/recipe/testrunner/__init__.py
+++ b/src/zc/recipe/testrunner/__init__.py
@@ -24,6 +24,7 @@ import pkg_resources
 
 import zc.buildout.easy_install
 import zc.recipe.egg
+from packaging.utils import canonicalize_name
 
 
 class TestRunner:
@@ -49,7 +50,12 @@ class TestRunner:
         for spec in eggs:
             dist = ws.find(pkg_resources.Requirement.parse(spec))
             if dist is None:
-                raise ValueError(f"Requirement not found in working set: {spec}")
+                new_spec = canonicalize_name(spec)
+                if spec != new_spec:
+                    dist = ws.find(pkg_resources.Requirement.parse(new_spec))
+                if dist is None:
+                    raise ValueError(
+                        f"Requirement not found in working set: {spec}")
             test_paths.append(dist.location)
 
         defaults = options.get('defaults', '').strip()

--- a/src/zc/recipe/testrunner/__init__.py
+++ b/src/zc/recipe/testrunner/__init__.py
@@ -45,8 +45,12 @@ class TestRunner:
         dest = []
         eggs, ws = self.egg.working_set(('zope.testrunner', ))
 
-        test_paths = [ws.find(pkg_resources.Requirement.parse(spec)).location
-                      for spec in eggs]
+        test_paths = []
+        for spec in eggs:
+            dist = ws.find(pkg_resources.Requirement.parse(spec))
+            if dist is None:
+                raise ValueError(f"Requirement not found in working set: {spec}")
+            test_paths.append(dist.location)
 
         defaults = options.get('defaults', '').strip()
         if defaults:


### PR DESCRIPTION
If distribution is not found, explicitly show its name.
Otherwise you get a very uninformative error:

```
While:
  Installing test.
...
  File "/home/runner/eggs/zc.recipe.testrunner-3.1-py3.10.egg/zc/recipe/testrunner/__init__.py", line 48, in install
    test_paths = [ws.find(pkg_resources.Requirement.parse(spec)).location
  File "/home/runner/eggs/zc.recipe.testrunner-3.1-py3.10.egg/zc/recipe/testrunner/__init__.py", line 48, in <listcomp>
    test_paths = [ws.find(pkg_resources.Requirement.parse(spec)).location
AttributeError: 'NoneType' object has no attribute 'location'
```

See for example [this test run](https://github.com/collective/collective.exportimport/actions/runs/14313320340/job/40167791654#step:8:1178).

With an explicit error raised, I see which package gives a problem:

```
ValueError: Requirement not found in working set: plone.app.upgrade
```

So in the second commit, we try the canonicalised name.