### PR TITLE
Fix egg specs with extras not found in working set

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Change History
 4.2 (unreleased)
 ================
 
-- Nothing changed yet.
+- Fix ``install()`` failing for egg specs with extras (e.g. ``pkg[test]``)
+  by stripping extras before canonicalizing the package name.
 
 
 4.1 (2026-04-23)

--- a/src/zc/recipe/testrunner/__init__.py
+++ b/src/zc/recipe/testrunner/__init__.py
@@ -23,6 +23,7 @@ import sys
 
 import zc.buildout.easy_install
 import zc.recipe.egg
+from packaging.requirements import Requirement as PackagingRequirement
 from packaging.utils import canonicalize_name
 
 
@@ -54,7 +55,8 @@ class TestRunner:
 
         test_paths = []
         for spec in eggs:
-            location = dist_map.get(canonicalize_name(spec))
+            name = PackagingRequirement(spec).name
+            location = dist_map.get(canonicalize_name(name))
             if location is None:  # pragma: no cover
                 raise ValueError(
                     f"Requirement not found in working set: {spec}")

--- a/src/zc/recipe/testrunner/tests.py
+++ b/src/zc/recipe/testrunner/tests.py
@@ -31,6 +31,13 @@ from setuptools import setup
 setup(name = "bugfix1")
 """
 
+EXTRAS_SETUP_PY = """\
+from setuptools import setup
+setup(
+    name="extrapkg",
+    extras_require={"test": []},
+)
+"""
 
 BUILDOUT_CFG = """\
 [buildout]
@@ -41,6 +48,19 @@ offline = true
 recipe = zc.recipe.testrunner
 eggs =
     bugfix1
+script = test
+working-directory = sample_working_dir
+"""
+
+EXTRAS_BUILDOUT_CFG = """\
+[buildout]
+develop = extrapkg
+parts = testextrapkg
+offline = true
+[testextrapkg]
+recipe = zc.recipe.testrunner
+eggs =
+    extrapkg[test]
 script = test
 working-directory = sample_working_dir
 """
@@ -135,6 +155,53 @@ class AbsPathTest(unittest.TestCase):
             self.assertIn(line, output)
 
 
+class ExtrasInEggsTest(unittest.TestCase):
+    """Eggs with extras like ``extrapkg[test]`` must be resolved correctly.
+
+    ``canonicalize_name('extrapkg[test]')`` produces ``'extrapkg[test]'``
+    (with the bracket suffix) which does not match the dist-map key
+    ``'extrapkg'``.  The install() method must strip extras before
+    canonicalizing.
+    """
+
+    def setUp(self):
+        self.location = os.getcwd()
+
+        self.tmp = tempfile.mkdtemp(prefix='sample-buildout')
+        write(self.tmp, 'buildout.cfg', EXTRAS_BUILDOUT_CFG)
+        mkdir(self.tmp, 'sample_working_dir')
+        mkdir(self.tmp, 'extrapkg')
+        mkdir(self.tmp, 'extrapkg', 'extrapkg')
+        write(self.tmp, 'extrapkg', 'extrapkg', '__init__.py', '')
+        write(self.tmp, 'extrapkg', 'extrapkg', 'tests.py', TESTS_PY)
+        write(self.tmp, 'extrapkg', 'setup.py', EXTRAS_SETUP_PY)
+        write(self.tmp, 'extrapkg', 'README.rst', '')
+
+        os.chdir(self.tmp)
+
+    def tearDown(self):
+        os.chdir(self.location)
+        shutil.rmtree(self.tmp)
+
+    def runTest(self):
+        # Building the buildout triggers install() which must handle
+        # extras in egg specs.  The bug causes:
+        #   ValueError: Requirement not found in working set: extrapkg[test]
+        zc.buildout.buildout.Buildout(
+            'buildout.cfg',
+            [('buildout', 'log-level', 'WARNING')]
+        ).init('fake-argument')
+
+        output = system(
+            os.path.join(
+                self.tmp,
+                'bin',
+                'test') +
+            ' --list-tests')
+        self.assertNotIn('Requirement not found', output)
+        self.assertNotIn('Error', output)
+
+
 def setUp(test):
     zc.buildout.testing.buildoutSetUp(test)
     zc.buildout.testing.install_develop('zc.recipe.testrunner', test)
@@ -209,4 +276,5 @@ def test_suite():
             optionflags=doctest.ELLIPSIS,
         ),
         AbsPathTest(),
+        ExtrasInEggsTest(),
     ))

--- a/src/zc/recipe/testrunner/tests.py
+++ b/src/zc/recipe/testrunner/tests.py
@@ -57,6 +57,7 @@ EXTRAS_BUILDOUT_CFG = """\
 develop = extrapkg
 parts = testextrapkg
 offline = true
+
 [testextrapkg]
 recipe = zc.recipe.testrunner
 eggs =


### PR DESCRIPTION
## Problem

`install()` passes egg specs containing extras (e.g. `extrapkg[test]`) directly to `canonicalize_name()`, which produces `extrapkg[test]` instead of `extrapkg`. This doesn't match the `dist_map` key, causing:

```
ValueError: Requirement not found in working set: extrapkg[test]
```

Bug introduced in b3579229a786c2aba733323e4675acf1c28b7a9d.

## Fix

Use `packaging.requirements.Requirement` to parse the spec and extract the bare package name before canonicalizing.

## Test

Added `ExtrasInEggsTest` that creates a buildout with `extrapkg[test]` in the eggs list.

— _PR created by GitHub Copilot_